### PR TITLE
Fix sample data URL for Single time point demo.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,8 +22,10 @@ export const SampleDataURLs = [
   {
     title: "Single time point",
     url:
-      "https://corsproxy.io/?url=https://github.com/mapmanager/MapManagerCore-Data/raw/refs/heads/main/data/web_map_manager_single_timepoint.mmap.zip",
-  },
+    // abb 20260617 fixing live demo with cursor
+    //   "https://corsproxy.io/?url=https://github.com/mapmanager/MapManagerCore-Data/raw/refs/heads/main/data/web_map_manager_single_timepoint.mmap.zip",
+      "https://media.githubusercontent.com/media/mapmanager/MapManagerCore-Data/refs/heads/main/data/web_map_manager_single_timepoint.mmap.zip",
+    },
 ];
 
 root.render(<MapManager plugins={plugins} sampleData={SampleDataURLs} />);


### PR DESCRIPTION
Use media.githubusercontent.com for the LFS zip binary instead of corsproxy.io and the GitHub raw LFS pointer URL.

Fixes "Failed to load image:" when clicking Single time point on the live demo.
Replaces broken corsproxy.io + GitHub raw URL with media.githubusercontent.com
for the actual LFS zip binary.